### PR TITLE
Modified Access Control Credentials Headers

### DIFF
--- a/modules/requestToApi.js
+++ b/modules/requestToApi.js
@@ -89,7 +89,7 @@ const requestToApi = (args: RequestToApi): Promise<any> => {
     try {
       const request = new XMLHttpRequest()
       request.timeout = timeout
-      request.withCredentials = true
+      //request.withCredentials = true
 
       if (request.upload) {
         request.upload.onerror = error => handleError(error, request, resolve)


### PR DESCRIPTION
Hey @CharlesMangwa, this PR fix the following ```Access-Control-Allow-Credentials``` error:
Request header field Access-Control-Allow-Credentials is not allowed by Access-Control-Allow-Headers in preflight response.