### PR TITLE
Change target to support older browsers with CRA < 2.0.0

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -29,7 +29,7 @@ const getPlugins = (env) => {
             loose: true,
             modules: false,
             targets: {
-              node: 'current',
+              browsers: '> 1%, last 2 versions',
             },
           },
         ],


### PR DESCRIPTION
I changed the target so that it will build in es2015 and support older browsers and also allow CRA to make a production build with the current stable version.

This fixes issue #9.

The main problem was that arrow functions were not transpiled in the output build.