### PR TITLE
Add regenerator runtime transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react": ">=15 || ^16"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "invariant": "^2.2.2",
     "prop-types": "^15.6.0"
   },
@@ -61,6 +62,7 @@
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.10",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -29,7 +29,8 @@ const getPlugins = (env) => {
             loose: true,
             modules: false,
             targets: {
-              browsers: '> 1%, last 2 versions',
+              node: 'current',
+              browser: '> 1%, last 2 versions',
             },
           },
         ],
@@ -37,7 +38,14 @@ const getPlugins = (env) => {
         'flow',
         'react',
       ],
-      plugins: ['external-helpers'].concat(
+      plugins: [
+        'external-helpers',
+        ['transform-runtime', {
+          helpers: false,
+          polyfill: false,
+          regenerator: true,
+        }],
+      ].concat(
         env === 'production'
           ? [
             'dev-expression',

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,6 +905,12 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "^0.10.0"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
@@ -1020,7 +1026,7 @@ babel-register@^6.26.0:
 
 babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  resolved "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"


### PR DESCRIPTION
I did a mistake yesterday in PR #10, and somehow didn't catch it until now. The async functions were transpiled to use the regenerator runtime, but it was not present so it crashed.

Here is the fix for it.

Sorry about that! 😅 